### PR TITLE
Full support for lutron shades

### DIFF
--- a/src/homeworksAccessory.ts
+++ b/src/homeworksAccessory.ts
@@ -16,10 +16,10 @@ export class HomeworksAccessory {
   public _dimmerState = {
     On: false,
     Brightness: 0,
-    PositionState: 2
+    PositionState: 2,
   }
 
-  private _name;
+  private readonly _name;
 
   constructor(
     private readonly _platform: HomeworksPlatform,
@@ -38,11 +38,12 @@ export class HomeworksAccessory {
     this._accessory.getService(this._platform.Service.AccessoryInformation)!
       .setCharacteristic(this._platform.Characteristic.Manufacturer, 'Homebridge')
       .setCharacteristic(this._platform.Characteristic.Model, 'Homeworks Plugin')
-      .setCharacteristic(this._platform.Characteristic.SerialNumber, 'n/a')
-      // .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '0.2');
+      .setCharacteristic(this._platform.Characteristic.SerialNumber, 'n/a');
+    // .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '0.2');
 
     if (this._deviceType === 'shade') {
-      this._service = this._accessory.getService(this._platform.Service.WindowCovering) || this._accessory.addService(this._platform.Service.WindowCovering);
+      this._service = this._accessory.getService(this._platform.Service.WindowCovering)
+        || this._accessory.addService(this._platform.Service.WindowCovering);
       this._service.setCharacteristic(this._platform.Characteristic.Name, _accessory.context.device.name);
 
       //  Current position of the shade
@@ -65,7 +66,8 @@ export class HomeworksAccessory {
 
     } else {
       //Assign HK Service
-      this._service = this._accessory.getService(this._platform.Service.Lightbulb) || this._accessory.addService(this._platform.Service.Lightbulb);
+      this._service = this._accessory.getService(this._platform.Service.Lightbulb)
+        || this._accessory.addService(this._platform.Service.Lightbulb);
       //Set Characteristic Name
       this._service.setCharacteristic(this._platform.Characteristic.Name, _accessory.context.device.name);
 
@@ -74,7 +76,7 @@ export class HomeworksAccessory {
         .on('set', this.setOn.bind(this))                // SET - bind to the `setOn` method below
         .on('get', this.getOn.bind(this));               // GET - bind to the `getOn` method below
       // register handlers for the Brightness Characteristic
-      if (_dimmable === true) {
+      if (_dimmable) {
         this._service.getCharacteristic(this._platform.Characteristic.Brightness)
           .on('set', this.setBrightness.bind(this))       // SET - bind to the 'setBrightness` method below
           .on('get', this.getBrightness.bind(this));      // GET - bind to the 'getBrightness` method below
@@ -144,7 +146,7 @@ export class HomeworksAccessory {
       this._dimmerState.Brightness = 0;
     }
 
-    if (this.getIsDimmable() === false) { //If we are not dimmable. Assume 100% brightness on on state.
+    if (!this.getIsDimmable()) { //If we are not dimmable. Assume 100% brightness on on state.
       this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);
     }
     
@@ -160,7 +162,7 @@ export class HomeworksAccessory {
   private getOn(callback: CharacteristicGetCallback) {
     const isOn = this._dimmerState.On;
 
-    if (isOn === true) {
+    if (isOn) {
       this._platform.log.debug('[Accessory][getOn] %s is ON', this.getName());
     } else {
       this._platform.log.debug('[Accessory][getOn] %s is OFF', this.getName());

--- a/src/homeworksAccessory.ts
+++ b/src/homeworksAccessory.ts
@@ -214,7 +214,7 @@ export class HomeworksLightAccessory extends HomeworksAccessory {
 
   /**
    * Called from processor when we need to update Homekit
-   * With new values from processor. (set externally)
+   * With new values from processor.
    */
   public updateBrightness(targetBrightnessVal: CharacteristicValue) {
     this._platform.log.info('[Accessory][%s][updateBrightness] to %i', this._name, targetBrightnessVal);
@@ -276,120 +276,9 @@ export class HomeworksShadeAccessory extends HomeworksAccessory {
     this._dimmerState.PositionState = this._platform.Characteristic.PositionState.STOPPED;
   }
 
-  //*************************************
-  //* Class Getters
-  /**
-   * Handle the "GET" integrationId
-   * @example
-   * getIntegrationId()
-   */
-  public getIntegrationId() {
-    return this._config.integrationID;
-  }
-
-  /**
-   * Handle the "GET" name
-   * @example
-   * getName()
-   */
-  public getName() {
-    return this._name;
-  }
-
-  /**
-   * Handle the "GET" UUID
-   * @example
-   * getUUID()
-   */
-  public getUUID() {
-    return this._uuid;
-  }
-
-
-  /**
-   * Handle the "GET" is dimmable
-   * @example
-   * getIsDimable()
-   */
-  public getIsDimmable() {
-    return this._config.isDimmable;
-  }
 
   //*************************************
   //* HomeBridge Delegates (Binds)
-
-  /**
-   * Handle the "SET/GET" ON requests from HomeKit
-   */
-
-  private setOn(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
-    const isDimmable = this.getIsDimmable();
-
-    if (targetValue === this._dimmerState.On) {
-      callback(null);
-      return;
-    }
-
-    this._dimmerState.On = targetValue as boolean;
-
-    if (targetValue === true) {
-      this._dimmerState.Brightness = 100;
-    } else {
-      this._dimmerState.Brightness = 0;
-    }
-
-    if (!this.getIsDimmable()) { //If we are not dimmable. Assume 100% brightness on on state.
-      this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);
-    }
-
-    if (this.lutronLevelChangeCallback) {
-      this.lutronLevelChangeCallback(this._dimmerState.Brightness, isDimmable, this);
-    }
-
-    this._platform.log.debug('[Accessory][%s][setOn] [state: %s|dim: %s]', this._name, this._dimmerState.On, this.getIsDimmable());
-
-    callback(null);
-  }
-
-  private getOn(callback: CharacteristicGetCallback) {
-    const isOn = this._dimmerState.On;
-
-    this._platform.log.debug('[Accessory][%s][getOn] is %s', this.getName(), isOn ? 'ON' : 'OFF');
-
-    callback(null, isOn); //error,value
-  }
-
-  /**
-   * Handle the "SET/GET" Brightness requests from HomeKit
-   */
-
-  private getBrightness(callback: CharacteristicGetCallback) {
-    const brightness = this._dimmerState.Brightness;
-
-    this._platform.log.debug('[Accessory][%s][getBrightness] -> %i', this._name, brightness);
-
-    callback(null, brightness); //error,value
-  }
-
-  private setBrightness(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
-
-    if (targetValue === this._dimmerState.Brightness) {
-      callback(null);
-      return;
-    }
-
-    this._platform.log.debug('[Accessory][%s][setBrightness] -> %i', this.getName(), targetValue);
-
-    const targetBrightnessVal = targetValue as number;
-    this._dimmerState.Brightness = targetBrightnessVal;
-
-    if (this.lutronLevelChangeCallback) {
-      this.lutronLevelChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
-    }
-
-
-    callback(null); // null or error
-  }
 
   /**
    * Handle the "SET/GET" CurrentPosition requests from HomeKit
@@ -416,7 +305,7 @@ export class HomeworksShadeAccessory extends HomeworksAccessory {
     this._dimmerState.Brightness = targetBrightnessVal;
 
     if (this.lutronLevelChangeCallback) {
-      this.lutronLevelChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
+      this.lutronLevelChangeCallback(targetBrightnessVal, false, this);
     }
 
     callback(null); // null or error
@@ -447,7 +336,7 @@ export class HomeworksShadeAccessory extends HomeworksAccessory {
     this._dimmerState.Brightness = targetBrightnessVal;
 
     if (this.lutronLevelChangeCallback) {
-      this.lutronLevelChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
+      this.lutronLevelChangeCallback(targetBrightnessVal, false, this);
     }
 
     callback(null); // null or error

--- a/src/homeworksAccessory.ts
+++ b/src/homeworksAccessory.ts
@@ -221,7 +221,7 @@ export class HomeworksAccessory {
 
   private setCurrentPosition(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this.platform.log.debug('[Accessory] Set CurrentPosition -> %i %s', targetValue, this.getName());
+    this.platform.log.info('[Accessory] Set CurrentPosition -> %i %s', targetValue, this.getName());
 
     if (targetValue === this.dimmerState.Brightness) {
       callback(null);
@@ -252,7 +252,7 @@ export class HomeworksAccessory {
 
   private setTargetPosition(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this.platform.log.debug('[Accessory] Set TargetPosition -> %i %s', targetValue, this.getName());
+    this.platform.log.info('[Accessory] Set TargetPosition -> %i %s', targetValue, this.getName());
 
     if (targetValue === this.dimmerState.Brightness) {
       callback(null);
@@ -274,16 +274,14 @@ export class HomeworksAccessory {
    */
 
   private getPositionState(callback: CharacteristicGetCallback) {
-    const brightness = this.dimmerState.Brightness;
-
-    this.platform.log.info('[Accessory] Get PositionState -> %i %s', brightness, this._name);
+    this.platform.log.info('[Accessory] Get PositionState -> %i %s', this.dimmerState.PositionState, this._name);
 
     callback(null, this.dimmerState.PositionState); //error,value
   }
 
   private setPositionState(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this.platform.log.debug('[Accessory] Set PositionState -> %i %s', targetValue, this.getName());
+    this.platform.log.info('[Accessory] Set PositionState -> %i %s', targetValue, this.getName());
 
     //  Don't know what to do here.
     callback(null); // null or error
@@ -296,12 +294,12 @@ export class HomeworksAccessory {
    * Called from processor when we need to update Homekit
    * With new values from processor. (set externally)
    */
-  public updateBrightness(targetBrightnessVal: CharacteristicValue) { 
+  public updateBrightness(targetBrightnessVal: CharacteristicValue) {
+    this.platform.log.info('[Accessory][updateBrightness] to %i for %s', targetBrightnessVal, this._name);
+
     if (targetBrightnessVal === this.dimmerState.Brightness) { //If the value is the same. Ignore to save network traffic.
       return; 
     }
-
-    this.platform.log.debug('[Accessory][updateBrightness] to %i for %s', targetBrightnessVal, this._name);
 
     if (targetBrightnessVal > 0) {
       this.dimmerState.On = true;

--- a/src/homeworksAccessory.ts
+++ b/src/homeworksAccessory.ts
@@ -8,80 +8,74 @@ interface SetLutronBrightnessCallback { (value: number, isDimmable:boolean, Acce
  * HomeworksAccessory
  * An instance of this class is created for each accessory your platform registers
  */
+
 export class HomeworksAccessory {
-  private service: Service;
+  private _service: Service;
   public lutronBrightnessChangeCallback? : SetLutronBrightnessCallback;
 
-  public dimmerState = {
+  public _dimmerState = {
     On: false,
     Brightness: 0,
     PositionState: 2
   }
 
   private _name;
-  private _integrationId;
-  private _UUID;
-  private _deviceType: string;
-  private _dimmable = true;
-  
+
   constructor(
-    private readonly platform: HomeworksPlatform,
-    private readonly accessory: PlatformAccessory,
-    private readonly uuid: string,
-    private readonly integrationId: string,
-    private readonly deviceType: string,
-    private readonly dimmable: boolean,
+    private readonly _platform: HomeworksPlatform,
+    private readonly _accessory: PlatformAccessory,
+    private readonly _uuid: string,
+    private readonly _integrationId: string,
+    private readonly _deviceType: string,
+    private readonly _dimmable: boolean,
   ) {
     
     //Assign local variables
-    this._name = accessory.context.device.name;
-    this._UUID = uuid;
-    this._integrationId = integrationId;
-    this._deviceType = deviceType || 'light';
-    this._dimmable = dimmable;
+    this._name = _accessory.context.device.name;
+    this._deviceType = this._deviceType || 'light';
 
     //Set Info
-    this.accessory.getService(this.platform.Service.AccessoryInformation)!
-      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Homebridge')
-      .setCharacteristic(this.platform.Characteristic.Model, 'Homeworks Plugin')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, 'n/a')
+    this._accessory.getService(this._platform.Service.AccessoryInformation)!
+      .setCharacteristic(this._platform.Characteristic.Manufacturer, 'Homebridge')
+      .setCharacteristic(this._platform.Characteristic.Model, 'Homeworks Plugin')
+      .setCharacteristic(this._platform.Characteristic.SerialNumber, 'n/a')
       // .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '0.2');
 
     if (this._deviceType === 'shade') {
-      this.service = this.accessory.getService(this.platform.Service.WindowCovering) || this.accessory.addService(this.platform.Service.WindowCovering);
-      this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.name);
+      this._service = this._accessory.getService(this._platform.Service.WindowCovering) || this._accessory.addService(this._platform.Service.WindowCovering);
+      this._service.setCharacteristic(this._platform.Characteristic.Name, _accessory.context.device.name);
 
       //  Current position of the shade
-      this.service.getCharacteristic(this.platform.Characteristic.CurrentPosition)
+      this._service.getCharacteristic(this._platform.Characteristic.CurrentPosition)
         .on('set', this.setCurrentPosition.bind(this))
         .on('get', this.getCurrentPosition.bind(this));
 
       //  Target position of the shade
-      this.service.getCharacteristic(this.platform.Characteristic.TargetPosition)
+      this._service.getCharacteristic(this._platform.Characteristic.TargetPosition)
         .on('set', this.setTargetPosition.bind(this))
         .on('get', this.getTargetPosition.bind(this));
 
       //  Current status of shade motion
       //  TODO: Is this ever invoked?
-      this.service.getCharacteristic(this.platform.Characteristic.PositionState)
+      this._service.getCharacteristic(this._platform.Characteristic.PositionState)
         .on('set', this.setPositionState.bind(this))
         .on('get', this.getPositionState.bind(this));
 
-      this.dimmerState.PositionState = this.platform.Characteristic.PositionState.STOPPED;
+      this._dimmerState.PositionState = this._platform.Characteristic.PositionState.STOPPED;
 
     } else {
       //Assign HK Service
-      this.service = this.accessory.getService(this.platform.Service.Lightbulb) || this.accessory.addService(this.platform.Service.Lightbulb);
+      this._service = this._accessory.getService(this._platform.Service.Lightbulb) || this._accessory.addService(this._platform.Service.Lightbulb);
       //Set Characteristic Name
-      this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.name);
+      this._service.setCharacteristic(this._platform.Characteristic.Name, _accessory.context.device.name);
 
       // register handlers for the On/Off Characteristic (minimum for lightbulb)
-      this.service.getCharacteristic(this.platform.Characteristic.On)
+      this._service.getCharacteristic(this._platform.Characteristic.On)
         .on('set', this.setOn.bind(this))                // SET - bind to the `setOn` method below
         .on('get', this.getOn.bind(this));               // GET - bind to the `getOn` method below
       // register handlers for the Brightness Characteristic
-      if (dimmable === true) {
-        this.service.getCharacteristic(this.platform.Characteristic.Brightness)
+      if (_dimmable === true) {
+        this._service.getCharacteristic(this._platform.Characteristic.Brightness)
           .on('set', this.setBrightness.bind(this))       // SET - bind to the 'setBrightness` method below
           .on('get', this.getBrightness.bind(this));      // GET - bind to the 'getBrightness` method below
       }
@@ -114,14 +108,14 @@ export class HomeworksAccessory {
    * getUUID() 
    */
   public getUUID() {
-    return this._UUID;
+    return this._uuid;
   }
 
 
   /**
-   * Handle the "GET" UUID
+   * Handle the "GET" is dimmable
    * @example
-   * getUUID() 
+   * getIsDimable()
    */
   public getIsDimmable() {
     return this._dimmable;
@@ -137,39 +131,39 @@ export class HomeworksAccessory {
   private setOn(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
     const isDimmable = this.getIsDimmable();
 
-    if (targetValue === this.dimmerState.On) {
+    if (targetValue === this._dimmerState.On) {
       callback(null);
       return; 
     } 
 
-    this.dimmerState.On = targetValue as boolean;
+    this._dimmerState.On = targetValue as boolean;
     
     if (targetValue === true) {
-      this.dimmerState.Brightness = 100;
+      this._dimmerState.Brightness = 100;
     } else {
-      this.dimmerState.Brightness = 0;
+      this._dimmerState.Brightness = 0;
     }
 
     if (this.getIsDimmable() === false) { //If we are not dimmable. Assume 100% brightness on on state.
-      this.service.updateCharacteristic(this.platform.Characteristic.Brightness, this.dimmerState.Brightness);
+      this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);
     }
     
     if (this.lutronBrightnessChangeCallback) {
-      this.lutronBrightnessChangeCallback(this.dimmerState.Brightness, isDimmable, this);
+      this.lutronBrightnessChangeCallback(this._dimmerState.Brightness, isDimmable, this);
     }
 
-    this.platform.log.debug('[Accessory][setOn] %s [name: %s|dim: %s]', this.dimmerState.On, this._name, this._dimmable);
+    this._platform.log.debug('[Accessory][setOn] %s [name: %s|dim: %s]', this._dimmerState.On, this._name, this._dimmable);
 
     callback(null);
   }
 
   private getOn(callback: CharacteristicGetCallback) {
-    const isOn = this.dimmerState.On;
+    const isOn = this._dimmerState.On;
 
     if (isOn === true) {
-      this.platform.log.debug('[Accessory][getOn] %s is ON', this.getName());
+      this._platform.log.debug('[Accessory][getOn] %s is ON', this.getName());
     } else {
-      this.platform.log.debug('[Accessory][getOn] %s is OFF', this.getName());
+      this._platform.log.debug('[Accessory][getOn] %s is OFF', this.getName());
     }
     
     callback(null, isOn); //error,value
@@ -180,27 +174,27 @@ export class HomeworksAccessory {
    */
 
   private getBrightness(callback: CharacteristicGetCallback) {    
-    const brightness = this.dimmerState.Brightness;
+    const brightness = this._dimmerState.Brightness;
 
-    this.platform.log.debug('[Accessory] Get Characteristic Brightness -> %i %s', brightness, this._name);
+    this._platform.log.debug('[Accessory] Get Characteristic Brightness -> %i %s', brightness, this._name);
     
     callback(null, brightness); //error,value
   }
 
   private setBrightness(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    if (targetValue === this.dimmerState.Brightness) {
+    if (targetValue === this._dimmerState.Brightness) {
       callback(null);
       return;
     }
     
-    this.platform.log.debug('[Accessory] Set Characteristic Brightness -> %i %s', targetValue, this.getName());
+    this._platform.log.debug('[Accessory] Set Characteristic Brightness -> %i %s', targetValue, this.getName());
 
     const targetBrightnessVal = targetValue as number;        
-    this.dimmerState.Brightness = targetBrightnessVal;
+    this._dimmerState.Brightness = targetBrightnessVal;
 
     if (this.lutronBrightnessChangeCallback) {
-      this.lutronBrightnessChangeCallback(targetBrightnessVal, this.getIsDimmable(), this); 
+      this.lutronBrightnessChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
     }
         
 
@@ -212,24 +206,24 @@ export class HomeworksAccessory {
    */
 
   private getCurrentPosition(callback: CharacteristicGetCallback) {
-    const brightness = this.dimmerState.Brightness;
+    const brightness = this._dimmerState.Brightness;
 
-    this.platform.log.info('[Accessory] Get CurrentPosition -> %i %s', brightness, this._name);
+    this._platform.log.info('[Accessory] Get CurrentPosition -> %i %s', brightness, this._name);
 
     callback(null, brightness); //error,value
   }
 
   private setCurrentPosition(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this.platform.log.info('[Accessory] Set CurrentPosition -> %i %s', targetValue, this.getName());
+    this._platform.log.info('[Accessory] Set CurrentPosition -> %i %s', targetValue, this.getName());
 
-    if (targetValue === this.dimmerState.Brightness) {
+    if (targetValue === this._dimmerState.Brightness) {
       callback(null);
       return;
     }
 
     const targetBrightnessVal = targetValue as number;
-    this.dimmerState.Brightness = targetBrightnessVal;
+    this._dimmerState.Brightness = targetBrightnessVal;
 
     if (this.lutronBrightnessChangeCallback) {
       this.lutronBrightnessChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
@@ -243,24 +237,24 @@ export class HomeworksAccessory {
    */
 
   private getTargetPosition(callback: CharacteristicGetCallback) {
-    const brightness = this.dimmerState.Brightness;
+    const brightness = this._dimmerState.Brightness;
 
-    this.platform.log.info('[Accessory] Get TargetPosition -> %i %s', brightness, this._name);
+    this._platform.log.info('[Accessory] Get TargetPosition -> %i %s', brightness, this._name);
 
     callback(null, brightness); //error,value
   }
 
   private setTargetPosition(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this.platform.log.info('[Accessory] Set TargetPosition -> %i %s', targetValue, this.getName());
+    this._platform.log.info('[Accessory] Set TargetPosition -> %i %s', targetValue, this.getName());
 
-    if (targetValue === this.dimmerState.Brightness) {
+    if (targetValue === this._dimmerState.Brightness) {
       callback(null);
       return;
     }
 
     const targetBrightnessVal = targetValue as number;
-    this.dimmerState.Brightness = targetBrightnessVal;
+    this._dimmerState.Brightness = targetBrightnessVal;
 
     if (this.lutronBrightnessChangeCallback) {
       this.lutronBrightnessChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
@@ -274,14 +268,14 @@ export class HomeworksAccessory {
    */
 
   private getPositionState(callback: CharacteristicGetCallback) {
-    this.platform.log.info('[Accessory] Get PositionState -> %i %s', this.dimmerState.PositionState, this._name);
+    this._platform.log.info('[Accessory] Get PositionState -> %i %s', this._dimmerState.PositionState, this._name);
 
-    callback(null, this.dimmerState.PositionState); //error,value
+    callback(null, this._dimmerState.PositionState); //error,value
   }
 
   private setPositionState(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this.platform.log.info('[Accessory] Set PositionState -> %i %s', targetValue, this.getName());
+    this._platform.log.info('[Accessory] Set PositionState -> %i %s', targetValue, this.getName());
 
     //  Don't know what to do here.
     callback(null); // null or error
@@ -295,20 +289,20 @@ export class HomeworksAccessory {
    * With new values from processor. (set externally)
    */
   public updateBrightness(targetBrightnessVal: CharacteristicValue) {
-    this.platform.log.info('[Accessory][updateBrightness] to %i for %s', targetBrightnessVal, this._name);
+    this._platform.log.info('[Accessory][updateBrightness] to %i for %s', targetBrightnessVal, this._name);
 
-    if (targetBrightnessVal === this.dimmerState.Brightness) { //If the value is the same. Ignore to save network traffic.
+    if (targetBrightnessVal === this._dimmerState.Brightness) { //If the value is the same. Ignore to save network traffic.
       return; 
     }
 
     if (targetBrightnessVal > 0) {
-      this.dimmerState.On = true;
+      this._dimmerState.On = true;
     } else if (targetBrightnessVal <= 0) {
-      this.dimmerState.On = false;                   
+      this._dimmerState.On = false;
     }    
     
-    this.dimmerState.Brightness = targetBrightnessVal as number;    
-    this.service.updateCharacteristic(this.platform.Characteristic.On, this.dimmerState.On);
-    this.service.updateCharacteristic(this.platform.Characteristic.Brightness, this.dimmerState.Brightness);
+    this._dimmerState.Brightness = targetBrightnessVal as number;
+    this._service.updateCharacteristic(this._platform.Characteristic.On, this._dimmerState.On);
+    this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);
   }
 }

--- a/src/homeworksAccessory.ts
+++ b/src/homeworksAccessory.ts
@@ -11,7 +11,231 @@ interface SetLutronLevelCallback { (value: number, isDimmable:boolean, Accessory
  * An instance of this class is created for each accessory your platform registers
  */
 
+
 export class HomeworksAccessory {
+  public static CreateAccessory(
+    platform: HomeworksPlatform,
+    accessory: PlatformAccessory,
+    uuid: string,
+    config: ConfigDevice,
+  ): HomeworksAccessory {
+    switch (config.deviceType) {
+      case 'shade':
+        return new HomeworksShadeAccessory(platform, accessory, uuid, config);
+      default:
+      case 'light':
+        return new HomeworksLightAccessory(platform, accessory, uuid, config);
+    }
+  }
+
+  public lutronLevelChangeCallback? : SetLutronLevelCallback;
+  protected readonly _name;
+
+  constructor (
+    protected readonly _platform: HomeworksPlatform,
+    protected readonly _accessory: PlatformAccessory,
+    protected readonly _uuid: string,
+    protected readonly _config: ConfigDevice,
+  ) {
+    //Assign local variables
+    this._name = this._accessory.context.device.name;
+
+    //Set Info
+    this._accessory.getService(this._platform.Service.AccessoryInformation)!
+      .setCharacteristic(this._platform.Characteristic.Manufacturer, 'Homebridge')
+      .setCharacteristic(this._platform.Characteristic.Model, 'Homeworks Plugin')
+      .setCharacteristic(this._platform.Characteristic.SerialNumber, 'n/a');
+    // .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '0.2');
+
+  }
+
+  /**
+   * Handle the "GET" integrationId
+   * @example
+   * getIntegrationId()
+   */
+  public getIntegrationId() {
+    return this._config.integrationID;
+  }
+
+  /**
+   * Handle the "GET" name
+   * @example
+   * getName()
+   */
+  public getName() {
+    return this._name;
+  }
+
+  /**
+   * Handle the "GET" UUID
+   * @example
+   * getUUID()
+   */
+  public getUUID() {
+    return this._uuid;
+  }
+
+  /**
+   * Called from processor when we need to update Homekit
+   * With new values from processor. (set externally)
+   */
+  public updateBrightness(targetBrightnessVal: CharacteristicValue) {
+    this._platform.log.error('[Accessory][HomeworksAccessory] [%s] updateBrightness %s not overridden', this._name, targetBrightnessVal);
+  }
+
+}
+
+export class HomeworksLightAccessory extends HomeworksAccessory {
+  private _service: Service;
+
+  public _dimmerState = {
+    On: false,
+    Brightness: 0,
+    PositionState: 2,
+  }
+
+  constructor(
+    platform: HomeworksPlatform,
+    accessory: PlatformAccessory,
+    uuid: string,
+    config: ConfigDevice,
+  ) {
+    super(platform, accessory, uuid, config);
+
+    //Assign HK Service
+    this._service = this._accessory.getService(this._platform.Service.Lightbulb)
+      || this._accessory.addService(this._platform.Service.Lightbulb);
+    //Set Characteristic Name
+    this._service.setCharacteristic(this._platform.Characteristic.Name, this._accessory.context.device.name);
+
+    // register handlers for the On/Off Characteristic (minimum for lightbulb)
+    this._service.getCharacteristic(this._platform.Characteristic.On)
+      .on('set', this.setOn.bind(this))                // SET - bind to the `setOn` method below
+      .on('get', this.getOn.bind(this));               // GET - bind to the `getOn` method below
+    // register handlers for the Brightness Characteristic
+    if (this._config.isDimmable) {
+      this._service.getCharacteristic(this._platform.Characteristic.Brightness)
+        .on('set', this.setBrightness.bind(this))       // SET - bind to the 'setBrightness` method below
+        .on('get', this.getBrightness.bind(this));      // GET - bind to the 'getBrightness` method below
+
+    }
+  }
+
+  //*************************************
+  //* Class Getters
+  /**
+   * Handle the "GET" is dimmable
+   * @example
+   * getIsDimable()
+   */
+  public getIsDimmable() {
+    return this._config.isDimmable;
+  }
+
+  //*************************************
+  //* HomeBridge Delegates (Binds)
+
+  /**
+   * Handle the "SET/GET" ON requests from HomeKit
+   */
+
+  private setOn(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
+    const isDimmable = this.getIsDimmable();
+
+    if (targetValue === this._dimmerState.On) {
+      callback(null);
+      return;
+    }
+
+    this._dimmerState.On = targetValue as boolean;
+
+    if (targetValue === true) {
+      this._dimmerState.Brightness = 100;
+    } else {
+      this._dimmerState.Brightness = 0;
+    }
+
+    if (!this.getIsDimmable()) { //If we are not dimmable. Assume 100% brightness on on state.
+      this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);
+    }
+
+    if (this.lutronLevelChangeCallback) {
+      this.lutronLevelChangeCallback(this._dimmerState.Brightness, isDimmable, this);
+    }
+
+    this._platform.log.debug('[Accessory][%s][setOn] [state: %s|dim: %s]', this._name, this._dimmerState.On, this.getIsDimmable());
+
+    callback(null);
+  }
+
+  private getOn(callback: CharacteristicGetCallback) {
+    const isOn = this._dimmerState.On;
+
+    this._platform.log.debug('[Accessory][%s][getOn] is %s', this.getName(), isOn ? 'ON' : 'OFF');
+
+    callback(null, isOn); //error,value
+  }
+
+  /**
+   * Handle the "SET/GET" Brightness requests from HomeKit
+   */
+
+  private getBrightness(callback: CharacteristicGetCallback) {
+    const brightness = this._dimmerState.Brightness;
+
+    this._platform.log.debug('[Accessory][%s][getBrightness] -> %i', this._name, brightness);
+
+    callback(null, brightness); //error,value
+  }
+
+  private setBrightness(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
+
+    if (targetValue === this._dimmerState.Brightness) {
+      callback(null);
+      return;
+    }
+
+    this._platform.log.debug('[Accessory][%s][setBrightness] -> %i', this.getName(), targetValue);
+
+    const targetBrightnessVal = targetValue as number;
+    this._dimmerState.Brightness = targetBrightnessVal;
+
+    if (this.lutronLevelChangeCallback) {
+      this.lutronLevelChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
+    }
+
+
+    callback(null); // null or error
+  }
+
+  //*************************************
+  //* Accessory Callbacks
+
+  /**
+   * Called from processor when we need to update Homekit
+   * With new values from processor. (set externally)
+   */
+  public updateBrightness(targetBrightnessVal: CharacteristicValue) {
+    this._platform.log.info('[Accessory][%s][updateBrightness] to %i', this._name, targetBrightnessVal);
+
+    if (targetBrightnessVal === this._dimmerState.Brightness) { //If the value is the same. Ignore to save network traffic.
+      return;
+    }
+
+    if (targetBrightnessVal > 0) {
+      this._dimmerState.On = true;
+    } else if (targetBrightnessVal <= 0) {
+      this._dimmerState.On = false;
+    }
+
+    this._dimmerState.Brightness = targetBrightnessVal as number;
+    this._service.updateCharacteristic(this._platform.Characteristic.On, this._dimmerState.On);
+    this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);
+  }
+}
+
+export class HomeworksShadeAccessory extends HomeworksAccessory {
   private _service: Service;
   public lutronLevelChangeCallback? : SetLutronLevelCallback;
 
@@ -21,68 +245,35 @@ export class HomeworksAccessory {
     PositionState: 2,
   }
 
-  private readonly _name;
-
   constructor(
-    private readonly _platform: HomeworksPlatform,
-    private readonly _accessory: PlatformAccessory,
-    private readonly _uuid: string,
-    private readonly _config: ConfigDevice,
+    platform: HomeworksPlatform,
+    accessory: PlatformAccessory,
+    uuid: string,
+    config: ConfigDevice,
   ) {
-    
-    //Assign local variables
-    this._name = _accessory.context.device.name;
-    //  Default is light
-    this._config.deviceType = this._config.deviceType || 'light';
+    super( platform, accessory, uuid, config);
 
-    //Set Info
-    this._accessory.getService(this._platform.Service.AccessoryInformation)!
-      .setCharacteristic(this._platform.Characteristic.Manufacturer, 'Homebridge')
-      .setCharacteristic(this._platform.Characteristic.Model, 'Homeworks Plugin')
-      .setCharacteristic(this._platform.Characteristic.SerialNumber, 'n/a');
-    // .setCharacteristic(this.platform.Characteristic.FirmwareRevision, '0.2');
+    this._service = this._accessory.getService(this._platform.Service.WindowCovering)
+      || this._accessory.addService(this._platform.Service.WindowCovering);
+    this._service.setCharacteristic(this._platform.Characteristic.Name, this._accessory.context.device.name);
 
-    if (this._config.deviceType === 'shade') {
-      this._service = this._accessory.getService(this._platform.Service.WindowCovering)
-        || this._accessory.addService(this._platform.Service.WindowCovering);
-      this._service.setCharacteristic(this._platform.Characteristic.Name, _accessory.context.device.name);
+    //  Current position of the shade
+    this._service.getCharacteristic(this._platform.Characteristic.CurrentPosition)
+      .on('set', this.setCurrentPosition.bind(this))
+      .on('get', this.getCurrentPosition.bind(this));
 
-      //  Current position of the shade
-      this._service.getCharacteristic(this._platform.Characteristic.CurrentPosition)
-        .on('set', this.setCurrentPosition.bind(this))
-        .on('get', this.getCurrentPosition.bind(this));
+    //  Target position of the shade
+    this._service.getCharacteristic(this._platform.Characteristic.TargetPosition)
+      .on('set', this.setTargetPosition.bind(this))
+      .on('get', this.getTargetPosition.bind(this));
 
-      //  Target position of the shade
-      this._service.getCharacteristic(this._platform.Characteristic.TargetPosition)
-        .on('set', this.setTargetPosition.bind(this))
-        .on('get', this.getTargetPosition.bind(this));
+    //  Current status of shade motion
+    //  TODO: Is this ever invoked?
+    this._service.getCharacteristic(this._platform.Characteristic.PositionState)
+      .on('set', this.setPositionState.bind(this))
+      .on('get', this.getPositionState.bind(this));
 
-      //  Current status of shade motion
-      //  TODO: Is this ever invoked?
-      this._service.getCharacteristic(this._platform.Characteristic.PositionState)
-        .on('set', this.setPositionState.bind(this))
-        .on('get', this.getPositionState.bind(this));
-
-      this._dimmerState.PositionState = this._platform.Characteristic.PositionState.STOPPED;
-
-    } else {
-      //Assign HK Service
-      this._service = this._accessory.getService(this._platform.Service.Lightbulb)
-        || this._accessory.addService(this._platform.Service.Lightbulb);
-      //Set Characteristic Name
-      this._service.setCharacteristic(this._platform.Characteristic.Name, _accessory.context.device.name);
-
-      // register handlers for the On/Off Characteristic (minimum for lightbulb)
-      this._service.getCharacteristic(this._platform.Characteristic.On)
-        .on('set', this.setOn.bind(this))                // SET - bind to the `setOn` method below
-        .on('get', this.getOn.bind(this));               // GET - bind to the `getOn` method below
-      // register handlers for the Brightness Characteristic
-      if (this._config.isDimmable) {
-        this._service.getCharacteristic(this._platform.Characteristic.Brightness)
-          .on('set', this.setBrightness.bind(this))       // SET - bind to the 'setBrightness` method below
-          .on('get', this.getBrightness.bind(this));      // GET - bind to the 'getBrightness` method below
-      }
-    }
+    this._dimmerState.PositionState = this._platform.Characteristic.PositionState.STOPPED;
   }
 
   //*************************************
@@ -90,7 +281,7 @@ export class HomeworksAccessory {
   /**
    * Handle the "GET" integrationId
    * @example
-   * getIntegrationId() 
+   * getIntegrationId()
    */
   public getIntegrationId() {
     return this._config.integrationID;
@@ -99,7 +290,7 @@ export class HomeworksAccessory {
   /**
    * Handle the "GET" name
    * @example
-   * getName() 
+   * getName()
    */
   public getName() {
     return this._name;
@@ -108,7 +299,7 @@ export class HomeworksAccessory {
   /**
    * Handle the "GET" UUID
    * @example
-   * getUUID() 
+   * getUUID()
    */
   public getUUID() {
     return this._uuid;
@@ -136,11 +327,11 @@ export class HomeworksAccessory {
 
     if (targetValue === this._dimmerState.On) {
       callback(null);
-      return; 
-    } 
+      return;
+    }
 
     this._dimmerState.On = targetValue as boolean;
-    
+
     if (targetValue === true) {
       this._dimmerState.Brightness = 100;
     } else {
@@ -150,12 +341,12 @@ export class HomeworksAccessory {
     if (!this.getIsDimmable()) { //If we are not dimmable. Assume 100% brightness on on state.
       this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);
     }
-    
+
     if (this.lutronLevelChangeCallback) {
       this.lutronLevelChangeCallback(this._dimmerState.Brightness, isDimmable, this);
     }
 
-    this._platform.log.debug('[Accessory][setOn] %s [name: %s|dim: %s]', this._dimmerState.On, this._name, this.getIsDimmable());
+    this._platform.log.debug('[Accessory][%s][setOn] [state: %s|dim: %s]', this._name, this._dimmerState.On, this.getIsDimmable());
 
     callback(null);
   }
@@ -163,20 +354,20 @@ export class HomeworksAccessory {
   private getOn(callback: CharacteristicGetCallback) {
     const isOn = this._dimmerState.On;
 
-    this._platform.log.debug('[Accessory][getOn] %s is %s', this.getName(), isOn ? 'ON' : 'OFF');
+    this._platform.log.debug('[Accessory][%s][getOn] is %s', this.getName(), isOn ? 'ON' : 'OFF');
 
     callback(null, isOn); //error,value
-  }    
+  }
 
   /**
    * Handle the "SET/GET" Brightness requests from HomeKit
    */
 
-  private getBrightness(callback: CharacteristicGetCallback) {    
+  private getBrightness(callback: CharacteristicGetCallback) {
     const brightness = this._dimmerState.Brightness;
 
-    this._platform.log.debug('[Accessory] Get Characteristic Brightness -> %i %s', brightness, this._name);
-    
+    this._platform.log.debug('[Accessory][%s][getBrightness] -> %i', this._name, brightness);
+
     callback(null, brightness); //error,value
   }
 
@@ -186,16 +377,16 @@ export class HomeworksAccessory {
       callback(null);
       return;
     }
-    
-    this._platform.log.debug('[Accessory] Set Characteristic Brightness -> %i %s', targetValue, this.getName());
 
-    const targetBrightnessVal = targetValue as number;        
+    this._platform.log.debug('[Accessory][%s][setBrightness] -> %i', this.getName(), targetValue);
+
+    const targetBrightnessVal = targetValue as number;
     this._dimmerState.Brightness = targetBrightnessVal;
 
     if (this.lutronLevelChangeCallback) {
       this.lutronLevelChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
     }
-        
+
 
     callback(null); // null or error
   }
@@ -207,14 +398,14 @@ export class HomeworksAccessory {
   private getCurrentPosition(callback: CharacteristicGetCallback) {
     const brightness = this._dimmerState.Brightness;
 
-    this._platform.log.info('[Accessory] Get CurrentPosition -> %i %s', brightness, this._name);
+    this._platform.log.info('[Accessory][%s][getCurrentPosition] -> %i', this._name, brightness);
 
     callback(null, brightness); //error,value
   }
 
   private setCurrentPosition(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this._platform.log.info('[Accessory] Set CurrentPosition -> %i %s', targetValue, this.getName());
+    this._platform.log.info('[Accessory][%s][setCurrentPosition] -> %i', this.getName(), targetValue);
 
     if (targetValue === this._dimmerState.Brightness) {
       callback(null);
@@ -238,14 +429,14 @@ export class HomeworksAccessory {
   private getTargetPosition(callback: CharacteristicGetCallback) {
     const brightness = this._dimmerState.Brightness;
 
-    this._platform.log.info('[Accessory] Get TargetPosition -> %i %s', brightness, this._name);
+    this._platform.log.info('[Accessory][%s][getTargetPosition] -> %i', this._name, brightness);
 
     callback(null, brightness); //error,value
   }
 
   private setTargetPosition(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this._platform.log.info('[Accessory] Set TargetPosition -> %i %s', targetValue, this.getName());
+    this._platform.log.info('[Accessory][%s][setTargetPosition] -> %i', this.getName(), targetValue);
 
     if (targetValue === this._dimmerState.Brightness) {
       callback(null);
@@ -267,14 +458,14 @@ export class HomeworksAccessory {
    */
 
   private getPositionState(callback: CharacteristicGetCallback) {
-    this._platform.log.info('[Accessory] Get PositionState -> %i %s', this._dimmerState.PositionState, this._name);
+    this._platform.log.info('[Accessory][%s][getPositionState] -> %i', this._name, this._dimmerState.PositionState);
 
     callback(null, this._dimmerState.PositionState); //error,value
   }
 
   private setPositionState(targetValue: CharacteristicValue, callback: CharacteristicSetCallback) {
 
-    this._platform.log.info('[Accessory] Set PositionState -> %i %s', targetValue, this.getName());
+    this._platform.log.info('[Accessory][%s][setPositionState] -> %i', this.getName(), targetValue);
 
     //  Don't know what to do here.
     callback(null); // null or error
@@ -288,18 +479,18 @@ export class HomeworksAccessory {
    * With new values from processor. (set externally)
    */
   public updateBrightness(targetBrightnessVal: CharacteristicValue) {
-    this._platform.log.info('[Accessory][updateBrightness] to %i for %s', targetBrightnessVal, this._name);
+    this._platform.log.info('[Accessory][%s][updateBrightness] to %i', this._name, targetBrightnessVal);
 
     if (targetBrightnessVal === this._dimmerState.Brightness) { //If the value is the same. Ignore to save network traffic.
-      return; 
+      return;
     }
 
     if (targetBrightnessVal > 0) {
       this._dimmerState.On = true;
     } else if (targetBrightnessVal <= 0) {
       this._dimmerState.On = false;
-    }    
-    
+    }
+
     this._dimmerState.Brightness = targetBrightnessVal as number;
     this._service.updateCharacteristic(this._platform.Characteristic.On, this._dimmerState.On);
     this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);

--- a/src/homeworksAccessory.ts
+++ b/src/homeworksAccessory.ts
@@ -2,7 +2,7 @@ import { Service, PlatformAccessory, CharacteristicValue, CharacteristicSetCallb
 import { HomeworksPlatform } from './platform';
 import { ConfigDevice} from './Schemas/device';
 
-interface SetLutronBrightnessCallback { (value: number, isDimmable:boolean, Accessory:HomeworksAccessory): void }
+interface SetLutronLevelCallback { (value: number, isDimmable:boolean, Accessory:HomeworksAccessory): void }
 
 
 //*************************************
@@ -13,7 +13,7 @@ interface SetLutronBrightnessCallback { (value: number, isDimmable:boolean, Acce
 
 export class HomeworksAccessory {
   private _service: Service;
-  public lutronBrightnessChangeCallback? : SetLutronBrightnessCallback;
+  public lutronLevelChangeCallback? : SetLutronLevelCallback;
 
   public _dimmerState = {
     On: false,
@@ -151,8 +151,8 @@ export class HomeworksAccessory {
       this._service.updateCharacteristic(this._platform.Characteristic.Brightness, this._dimmerState.Brightness);
     }
     
-    if (this.lutronBrightnessChangeCallback) {
-      this.lutronBrightnessChangeCallback(this._dimmerState.Brightness, isDimmable, this);
+    if (this.lutronLevelChangeCallback) {
+      this.lutronLevelChangeCallback(this._dimmerState.Brightness, isDimmable, this);
     }
 
     this._platform.log.debug('[Accessory][setOn] %s [name: %s|dim: %s]', this._dimmerState.On, this._name, this.getIsDimmable());
@@ -192,8 +192,8 @@ export class HomeworksAccessory {
     const targetBrightnessVal = targetValue as number;        
     this._dimmerState.Brightness = targetBrightnessVal;
 
-    if (this.lutronBrightnessChangeCallback) {
-      this.lutronBrightnessChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
+    if (this.lutronLevelChangeCallback) {
+      this.lutronLevelChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
     }
         
 
@@ -224,8 +224,8 @@ export class HomeworksAccessory {
     const targetBrightnessVal = targetValue as number;
     this._dimmerState.Brightness = targetBrightnessVal;
 
-    if (this.lutronBrightnessChangeCallback) {
-      this.lutronBrightnessChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
+    if (this.lutronLevelChangeCallback) {
+      this.lutronLevelChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
     }
 
     callback(null); // null or error
@@ -255,8 +255,8 @@ export class HomeworksAccessory {
     const targetBrightnessVal = targetValue as number;
     this._dimmerState.Brightness = targetBrightnessVal;
 
-    if (this.lutronBrightnessChangeCallback) {
-      this.lutronBrightnessChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
+    if (this.lutronLevelChangeCallback) {
+      this.lutronLevelChangeCallback(targetBrightnessVal, this.getIsDimmable(), this);
     }
 
     callback(null); // null or error

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -95,7 +95,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
       //  NOTE: If the device is being updated elsewhere (like another app or switch) this
       //  value may be incorrect
       for (const accessory of this.homeworksAccessories) {
-        this.log.debug('[Platform] Requesting updates for:', accessory.getName());
+        this.log.debug('[Platform] Requesting level for:', accessory.getName());
         const command = `?OUTPUT,${accessory.getIntegrationId()},1`;
         engine.send(command);        
       }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -168,7 +168,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
         const hwa =
           new HomeworksAccessory(this, loadedAccessory, loadedAccessory.UUID, confDevice);
         this.homeworksAccessories.push(hwa);
-        hwa.lutronBrightnessChangeCallback = brightnessChangeCallback;
+        hwa.lutronLevelChangeCallback = brightnessChangeCallback;
         allAddedAccesories.push(loadedAccessory);
       } else {
         this.log.error('[platform][Error] Unable to load accessory: %s', confDevice.name);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -165,7 +165,8 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
 
         this.log.info('[Platform] Registering: %s as %s Dimmable: %s', loadedAccessory.displayName, confDevice.name, isDimmable);
         // eslint-disable-next-line max-len
-        const hwa = new HomeworksAccessory(this, loadedAccessory, loadedAccessory.UUID, confDevice.integrationID, confDevice.deviceType, isDimmable);
+        const hwa =
+          new HomeworksAccessory(this, loadedAccessory, loadedAccessory.UUID, confDevice);
         this.homeworksAccessories.push(hwa);
         hwa.lutronBrightnessChangeCallback = brightnessChangeCallback;
         allAddedAccesories.push(loadedAccessory);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -11,7 +11,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
   private configuration: Configuration = {devices:[], apiPort:23, host:'127.0.0.1', username:'', password:''};
   private readonly engine: NetworkEngine;
   private readonly cachedPlatformAccessories: PlatformAccessory[] = [];
-  private readonly homeworksAccesories: HomeworksAccessory[] = [];
+  private readonly homeworksAccessories: HomeworksAccessory[] = [];
 
   constructor(
     public readonly log: Logger,
@@ -79,7 +79,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
           const deviceId = splittedMessage[1];  //Assign values from splitted message
           const brigthness = Number(splittedMessage[splittedMessage.length-1]);
           const uuid = this.api.hap.uuid.generate(deviceId);
-          const targetDevice = this.homeworksAccesories.find(accessory => accessory.getUUID() === uuid);
+          const targetDevice = this.homeworksAccessories.find(accessory => accessory.getUUID() === uuid);
         
           if (targetDevice) { //If we find a device, it means we are observing it and need the value.
             this.log.debug('[Platform][EngineCallback] Set: %s to: %i', targetDevice.getName(), brigthness);
@@ -93,7 +93,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
     // * Will be called eveytime we connect to the processor (socket)
     const connectedCallback = (engine: NetworkEngine) : void => {      
       //When we connect. We want to get the latest state for the lights. So we issue a query
-      for (const accessory of this.homeworksAccesories) {
+      for (const accessory of this.homeworksAccessories) {
         this.log.debug('[Platform] Requesting updates for:', accessory.getName());
         const command = `?OUTPUT,${accessory.getIntegrationId()},1`;
         engine.send(command);        
@@ -166,7 +166,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
 
         this.log.info('[Platform] Registering: %s as %s Dimmable: %s', loadedAccessory.displayName, confDevice.name, isDimmable);
         const hwa = new HomeworksAccessory(this, loadedAccessory, loadedAccessory.UUID, confDevice.integrationID, confDevice.deviceType, isDimmable);
-        this.homeworksAccesories.push(hwa);
+        this.homeworksAccessories.push(hwa);
         hwa.lutronBrightnessChangeCallback = brightnessChangeCallback;
         allAddedAccesories.push(loadedAccessory);
       } else {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -41,8 +41,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
    * Loads and parses de user config.json for this platform
    */
   private loadUserConfiguration() {
-    const obj = JSON.parse(JSON.stringify(this.config));
-    this.configuration = obj;      
+    this.configuration = JSON.parse(JSON.stringify(this.config));
     this.log.debug('[Platform] User Configuration Loaded.');
   }
 
@@ -64,13 +63,13 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
           continue; 
         }
        
-        if (singleMessage.includes('~SYSTEM,6,') === true) { //This is considered a PONG reply.
+        if (singleMessage.includes('~SYSTEM,6,')) { //This is considered a PONG reply.
           this.log.debug('[platform][Pong] Received'); //TODO: Move to NETWORK Class (why waste cycles here)
           continue;
         }
 
-        if (singleMessage.includes('GLINK_DEVICE_SERIAL_NUM') !== true &&
-            singleMessage.includes('Device serial ') !== true) {
+        if (!singleMessage.includes('GLINK_DEVICE_SERIAL_NUM') &&
+            !singleMessage.includes('Device serial ')) {
           this.log.debug('[platform][traffic]', singleMessage);
         }
       
@@ -122,7 +121,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
     const brightnessChangeCallback = (value: number, isDimmable: boolean, accessory:HomeworksAccessory) : void => { //Callback from HK
       let fadeTime = '00:01';
       
-      if (isDimmable === false) {        
+      if (!isDimmable) {
         fadeTime = '00:00';
       }
       
@@ -165,6 +164,7 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
         
 
         this.log.info('[Platform] Registering: %s as %s Dimmable: %s', loadedAccessory.displayName, confDevice.name, isDimmable);
+        // eslint-disable-next-line max-len
         const hwa = new HomeworksAccessory(this, loadedAccessory, loadedAccessory.UUID, confDevice.integrationID, confDevice.deviceType, isDimmable);
         this.homeworksAccessories.push(hwa);
         hwa.lutronBrightnessChangeCallback = brightnessChangeCallback;
@@ -174,8 +174,8 @@ export class HomeworksPlatform implements DynamicPlatformPlugin {
       }            
     }
 
-    let toDelete: PlatformAccessory[] = [];
-    toDelete = this.diference(this.cachedPlatformAccessories, allAddedAccesories) as PlatformAccessory[];
+    const toDelete =
+      this.diference(this.cachedPlatformAccessories, allAddedAccesories) as PlatformAccessory[];
     if (toDelete.length > 0) {
       this.log.warn('[platform] Removing: %i accesories', toDelete.length);
       this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, toDelete);


### PR DESCRIPTION
This completes the work (that you merged part of) to enable lutron shades:
- Creating a device requires specifying 'light' or 'shade' in the dropdown
- Separate classes for lights/shades since their protocols are different
- Some small cleanups

Tested in my home!

Might be worth a version bump...